### PR TITLE
remove sqlx runtime features from the library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,20 @@ categories = ["web-programming::http-server", "web-programming", "database"]
 features = ["pg", "sqlite", "mysql", "async_std"]
 
 [features]
-default = ["native-tls"]
 sqlite = ["sqlx/sqlite"]
 pg = ["sqlx/postgres", "sqlx/json"]
-native-tls = ["sqlx/runtime-async-std-native-tls"]
-rustls = ["sqlx/runtime-async-std-rustls"]
-async_std = ["async-std"]
 mysql = ["sqlx/mysql", "sqlx/json"]
+
+async_std = ["dep:async-std"]
 
 [dependencies]
 async-session = "3.0.0"
-sqlx = { version = "0.6.2", features = ["chrono"] }
+sqlx = { version = "0.6.3", features = ["chrono"] }
 async-std = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 
 [dev-dependencies.sqlx]
-version = "0.6.2"
+version = "0.6.3"
 features = ["chrono", "runtime-async-std-native-tls"]


### PR DESCRIPTION
According to the cargo book ([source](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification)):

> When a dependency is used by multiple packages, Cargo will use the union of all features enabled on that dependency when building it. This helps ensure that only a single copy of the dependency is used. See the features section of the resolver documentation for more details.

So, the library should actually not force a sqlx runtime to the end-user. The library should let the user decide which runtime to enable and cargo will unify everything by itself.

This is obviously not backward compatible with the current release so I guess a `0.5.0` might be required. I just not sure if I should include the bump of version in my PR :) 