### PR TITLE
chore: bump sqlx to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ mysql = ["sqlx/mysql", "sqlx/json"]
 
 [dependencies]
 async-session = "3.0.0"
-sqlx = { version = "0.6.2", features = ["chrono"] }
+sqlx = { version = "0.7.1", features = ["chrono"] }
 async-std = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 
 [dev-dependencies.sqlx]
-version = "0.6.2"
+version = "0.7.1"
 features = ["chrono", "runtime-async-std-native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,14 @@ async_std = ["async-std"]
 mysql = ["sqlx/mysql", "sqlx/json"]
 
 [dependencies]
-async-session = "3.0.0"
-sqlx = { version = "0.7.1", features = ["chrono"] }
+async-session = { git = "https://github.com/http-rs/async-session", branch = "main"}
+sqlx = { version = "0.7.1", features = [ "time" ] }
 async-std = { version = "1.12.0", optional = true }
+time = "0.3.18"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 
 [dev-dependencies.sqlx]
 version = "0.7.1"
-features = ["chrono", "runtime-async-std-native-tls"]
+features = ["runtime-async-std-native-tls"]

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -235,7 +235,7 @@ impl MySqlSessionStore {
         let mut connection = self.connection().await?;
         sqlx::query(&self.substitute_table_name("DELETE FROM %%TABLE_NAME%% WHERE expires < ?"))
             .bind(Utc::now())
-            .execute(&mut connection)
+            .execute(&mut *connection)
             .await?;
 
         Ok(())
@@ -261,7 +261,7 @@ impl MySqlSessionStore {
     pub async fn count(&self) -> sqlx::Result<i64> {
         let (count,) =
             sqlx::query_as(&self.substitute_table_name("SELECT COUNT(*) FROM %%TABLE_NAME%%"))
-                .fetch_one(&mut self.connection().await?)
+                .fetch_one(&mut *self.connection().await?)
                 .await?;
 
         Ok(count)
@@ -279,7 +279,7 @@ impl SessionStore for MySqlSessionStore {
         ))
         .bind(&id)
         .bind(Utc::now())
-        .fetch_optional(&mut connection)
+        .fetch_optional(&mut *connection)
         .await?;
 
         Ok(result
@@ -304,7 +304,7 @@ impl SessionStore for MySqlSessionStore {
         .bind(&id)
         .bind(&string)
         .bind(&session.expiry())
-        .execute(&mut connection)
+        .execute(&mut *connection)
         .await?;
 
         Ok(session.into_cookie_value())
@@ -315,7 +315,7 @@ impl SessionStore for MySqlSessionStore {
         let mut connection = self.connection().await?;
         sqlx::query(&self.substitute_table_name("DELETE FROM %%TABLE_NAME%% WHERE id = ?"))
             .bind(&id)
-            .execute(&mut connection)
+            .execute(&mut *connection)
             .await?;
 
         Ok(())
@@ -324,7 +324,7 @@ impl SessionStore for MySqlSessionStore {
     async fn clear_store(&self) -> Result {
         let mut connection = self.connection().await?;
         sqlx::query(&self.substitute_table_name("TRUNCATE %%TABLE_NAME%%"))
-            .execute(&mut connection)
+            .execute(&mut *connection)
             .await?;
 
         Ok(())
@@ -362,7 +362,7 @@ mod tests {
 
         let (id, expires, serialized, count): (String, Option<DateTime<Utc>>, String, i64) =
             sqlx::query_as("select id, expires, session, (select count(*) from async_sessions) from async_sessions")
-                .fetch_one(&mut store.connection().await?)
+                .fetch_one(&mut *store.connection().await?)
                 .await?;
 
         assert_eq!(1, count);
@@ -399,7 +399,7 @@ mod tests {
 
         let (id, count): (String, i64) =
             sqlx::query_as("select id, (select count(*) from async_sessions) from async_sessions")
-                .fetch_one(&mut store.connection().await?)
+                .fetch_one(&mut *store.connection().await?)
                 .await?;
 
         assert_eq!(1, count);
@@ -429,7 +429,7 @@ mod tests {
         let (id, expires, count): (String, DateTime<Utc>, i64) = sqlx::query_as(
             "select id, expires, (select count(*) from async_sessions) from async_sessions",
         )
-        .fetch_one(&mut store.connection().await?)
+        .fetch_one(&mut *store.connection().await?)
         .await?;
 
         assert_eq!(1, count);
@@ -451,7 +451,7 @@ mod tests {
 
         let (id, expires, serialized, count): (String, Option<DateTime<Utc>>, String, i64) =
             sqlx::query_as("select id, expires, session, (select count(*) from async_sessions) from async_sessions")
-                .fetch_one(&mut store.connection().await?)
+                .fetch_one(&mut *store.connection().await?)
                 .await?;
 
         assert_eq!(1, count);

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -360,7 +360,7 @@ mod tests {
         let cloned = session.clone();
         let cookie_value = store.store_session(session).await?.unwrap();
 
-        let (id, expires, serialized, count): (String, Option<DateTime<Utc>>, String, i64) =
+        let (id, expires, serialized, count): (String, Option<DateTime>, String, i64) =
             sqlx::query_as("select id, expires, session, (select count(*) from async_sessions) from async_sessions")
                 .fetch_one(&mut *store.connection().await?)
                 .await?;
@@ -426,7 +426,7 @@ mod tests {
         let session = store.load_session(cookie_value.clone()).await?.unwrap();
         assert_eq!(session.expiry().unwrap(), &new_expires);
 
-        let (id, expires, count): (String, DateTime<Utc>, i64) = sqlx::query_as(
+        let (id, expires, count): (String, DateTime, i64) = sqlx::query_as(
             "select id, expires, (select count(*) from async_sessions) from async_sessions",
         )
         .fetch_one(&mut *store.connection().await?)
@@ -449,7 +449,7 @@ mod tests {
 
         let cookie_value = store.store_session(session).await?.unwrap();
 
-        let (id, expires, serialized, count): (String, Option<DateTime<Utc>>, String, i64) =
+        let (id, expires, serialized, count): (String, Option<DateTime>, String, i64) =
             sqlx::query_as("select id, expires, session, (select count(*) from async_sessions) from async_sessions")
                 .fetch_one(&mut *store.connection().await?)
                 .await?;

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -238,7 +238,7 @@ impl SqliteSessionStore {
             "#,
         ))
         .bind(Utc::now().timestamp())
-        .execute(&mut connection)
+        .execute(&mut *connection)
         .await?;
 
         Ok(())
@@ -263,7 +263,7 @@ impl SqliteSessionStore {
     pub async fn count(&self) -> sqlx::Result<i32> {
         let (count,) =
             sqlx::query_as(&self.substitute_table_name("SELECT COUNT(*) FROM %%TABLE_NAME%%"))
-                .fetch_one(&mut self.connection().await?)
+                .fetch_one(&mut *self.connection().await?)
                 .await?;
 
         Ok(count)
@@ -284,7 +284,7 @@ impl SessionStore for SqliteSessionStore {
         ))
         .bind(&id)
         .bind(Utc::now().timestamp())
-        .fetch_optional(&mut connection)
+        .fetch_optional(&mut *connection)
         .await?;
 
         Ok(result
@@ -309,7 +309,7 @@ impl SessionStore for SqliteSessionStore {
         .bind(&id)
         .bind(&string)
         .bind(&session.expiry().map(|expiry| expiry.timestamp()))
-        .execute(&mut connection)
+        .execute(&mut *connection)
         .await?;
 
         Ok(session.into_cookie_value())
@@ -324,7 +324,7 @@ impl SessionStore for SqliteSessionStore {
             "#,
         ))
         .bind(&id)
-        .execute(&mut connection)
+        .execute(&mut *connection)
         .await?;
 
         Ok(())
@@ -337,7 +337,7 @@ impl SessionStore for SqliteSessionStore {
             DELETE FROM %%TABLE_NAME%%
             "#,
         ))
-        .execute(&mut connection)
+        .execute(&mut *connection)
         .await?;
 
         Ok(())
@@ -370,7 +370,7 @@ mod tests {
 
         let (id, expires, serialized, count): (String, Option<i64>, String, i64) =
             sqlx::query_as("select id, expires, session, count(*) from async_sessions")
-                .fetch_one(&mut store.connection().await?)
+                .fetch_one(&mut *store.connection().await?)
                 .await?;
 
         assert_eq!(1, count);
@@ -406,7 +406,7 @@ mod tests {
         assert_eq!(session.get::<String>("key").unwrap(), "other value");
 
         let (id, count): (String, i64) = sqlx::query_as("select id, count(*) from async_sessions")
-            .fetch_one(&mut store.connection().await?)
+            .fetch_one(&mut *store.connection().await?)
             .await?;
 
         assert_eq!(1, count);
@@ -435,7 +435,7 @@ mod tests {
 
         let (id, expires, count): (String, i64, i64) =
             sqlx::query_as("select id, expires, count(*) from async_sessions")
-                .fetch_one(&mut store.connection().await?)
+                .fetch_one(&mut *store.connection().await?)
                 .await?;
 
         assert_eq!(1, count);
@@ -457,7 +457,7 @@ mod tests {
 
         let (id, expires, serialized, count): (String, Option<i64>, String, i64) =
             sqlx::query_as("select id, expires, session, count(*) from async_sessions")
-                .fetch_one(&mut store.connection().await?)
+                .fetch_one(&mut *store.connection().await?)
                 .await?;
 
         assert_eq!(1, count);


### PR DESCRIPTION
As per https://github.com/jbr/async-sqlx-session/pull/32